### PR TITLE
Fix README build/test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ Local check total time: 13.260296821594238
 * Python 3.6 or greater 
 * Cmake 3.6 or greater 
 
-## To build 
+## To build
 
-```source install.bash``` 
+```
+pip install -e .
+```
 
 Test it with
 
-```python3 test_poly.py``` 
+```
+python examples/polytest.py
+```
  


### PR DESCRIPTION
## Summary
- update build and test commands in README

## Testing
- `PYTHONPATH=. python examples/polytest.py` *(fails: ModuleNotFoundError: No module named 'pycuda')*
- `pip install -e .` *(fails: could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865457f20e083228cc81c0bd06caace